### PR TITLE
feat: regra de deleção de usuário inativo por mais de 180 dias funcio…

### DIFF
--- a/py_controller/settings.py
+++ b/py_controller/settings.py
@@ -45,6 +45,7 @@ DJANGO_APPS = [
 
 THIRD_PARTY_APPS = [
     "rest_framework",
+    "django_crontab",
 ]
 
 MY_APPS = [
@@ -150,3 +151,5 @@ STATIC_URL = "static/"
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 AUTH_USER_MODEL = "users.User"
+
+CRONJOBS = [("0 0 * * *", "users.tasks.delete_inactive_users")]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ click==8.1.3
 dark==0.7.1
 decorator==5.1.1
 Django==4.1.5
+django-crontab==0.7.1
 djangorestframework==3.14.0
 executing==1.2.0
 ipdb==0.13.11

--- a/users/tasks.py
+++ b/users/tasks.py
@@ -1,0 +1,13 @@
+from datetime import timedelta
+from django.utils import timezone
+from django.contrib.auth import get_user_model
+
+
+def delete_inactive_users():
+    User = get_user_model()
+    time_to_inactive = timedelta(days=180)
+    now = timezone.now()
+    inactive_users = User.objects.filter(
+        is_active=False, last_login__lte=now - time_to_inactive
+    )
+    inactive_users.delete()


### PR DESCRIPTION
…nando utilizando o modulo 'django-contrab para criação desta tarefa agendada e configurando para ser verificado todos os dias a 00hrs'